### PR TITLE
GitVersion fix

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: ContinuousDeployment
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,6 @@ pr:
   branches:
     include:
       - master
-      - develop
-      - releases/*
   paths:
     exclude:
       - docs/*


### PR DESCRIPTION
- Added `GitVersion.yml` config to fix version for prerelease NuGet packages.
- Removed reference to `develop` and `release` branches, as they aren't used currently.